### PR TITLE
Upgrade metrics to v0.21 and bump MSRV to 1.61

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "metrics-exporter-dogstatsd"
 version = "0.7.0"
 authors = ["Valentino Volonghi <dialtone@nextroll.com>"]
 edition = "2021"
-rust-version="1.56.1"
+rust-version="1.61.0"
 
 license = "MIT"
 
@@ -17,12 +17,11 @@ categories = ["development-tools::debugging"]
 keywords = ["metrics", "telemetry", "statsd"]
 
 [dependencies]
-metrics = "0.20"
-metrics-util = { version = "0.14" , default-features = false, features = ["recency", "registry", "summary"] }
+metrics = "0.21"
+metrics-util = { version = "0.15", default-features = false, features = ["recency", "registry", "summary"] }
 thiserror = { version = "1", default-features = false }
-quanta = { version = "0.10.0", default-features = false }
+quanta = { version = "0.11.0", default-features = false }
 indexmap = { version = "1", default-features = false }
-portable-atomic = "0.3"
 
 tokio = { version = "1", features = ["rt", "net", "time"] }
 tracing = { version = "0.1.26" }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -112,10 +112,7 @@ impl StatsdBuilder {
                 )
             })?;
 
-        self.exporter_config = ExporterConfig::PushGateway {
-            endpoint: endpoint,
-            interval,
-        };
+        self.exporter_config = ExporterConfig::PushGateway { endpoint, interval };
 
         Ok(self)
     }

--- a/src/formatting.rs
+++ b/src/formatting.rs
@@ -13,7 +13,7 @@ pub fn key_to_parts(
 ) -> (String, Vec<String>) {
     let name = sanitize_metric_name(key.name());
     let mut values = default_labels.cloned().unwrap_or_default();
-    key.labels().into_iter().for_each(|label| {
+    key.labels().for_each(|label| {
         values.insert(label.key().to_string(), label.value().to_string());
     });
     let labels = values

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -1,6 +1,6 @@
-use portable_atomic::AtomicU64;
 use std::sync::Arc;
 
+use metrics::atomics::AtomicU64;
 use metrics::HistogramFn;
 use metrics_util::registry::GenerationalStorage;
 use metrics_util::AtomicBucket;


### PR DESCRIPTION
Hi. Thanks for making this crate!

I found the current version v0.7.0 does not support the latest version of `metrics` ([v0.21.0](https://crates.io/crates/metrics/0.21.0)). When I recorded some metrics using `metrics` v0.21.0 in my app, `metrics-exporter-dogstatsd` did not export anything.

This PR upgrades `metrics` and related crates to the latest version. It also bumps the minimum supported Rust version (MSRV to 1.61):

- Bump the MSRV to 1.61 (because metrics v0.21's MSRV is 1.61).
- Upgrade dependencies:
    - metrics v0.21 ([changelog](https://github.com/metrics-rs/metrics/blob/main/metrics/CHANGELOG.md#0210---2023-04-16))
    - metrics-util v0.15 ([changelog](https://github.com/metrics-rs/metrics/blob/main/metrics-util/CHANGELOG.md#0150---2023-04-16))
    - quanta v0.11.0 ([changelog](https://github.com/metrics-rs/quanta/blob/main/CHANGELOG.md#0110---2023-03-24))
- Remove a dependency `portable-atomic`. (Switch to `metrics`-exposed version of `AtomicU64`)

Tested locally on macOS Ventura 13.3.1 (arm64), with `metrics` v0.21.0 and a statsd server (Netdata).