### PR TITLE
Do not suppress 0 values

### DIFF
--- a/src/recorder.rs
+++ b/src/recorder.rs
@@ -51,7 +51,7 @@ impl Inner {
             }
 
             let (name, labels) = key_to_parts(&key, Some(&self.global_tags));
-            let value = f64::from_bits(gauge.get_inner().swap(0, Ordering::Acquire));
+            let value = f64::from_bits(gauge.get_inner().load(Ordering::Acquire));
             let entry = gauges
                 .entry(name)
                 .or_insert_with(HashMap::new)
@@ -103,9 +103,6 @@ impl Inner {
         for (name, mut by_labels) in counters.drain() {
             let mut wrote = false;
             for (labels, value) in by_labels.drain() {
-                if value == 0 {
-                    continue;
-                }
                 wrote = true;
                 write_metric_line::<&str, u64>(
                     &mut output,
@@ -128,9 +125,6 @@ impl Inner {
         for (name, mut by_labels) in gauges.drain() {
             let mut wrote = false;
             for (labels, value) in by_labels.drain() {
-                if value == 0.0 {
-                    continue;
-                }
                 wrote = true;
                 write_metric_line::<&str, f64>(
                     &mut output,
@@ -156,9 +150,6 @@ impl Inner {
                 let (sum, count) = match distribution {
                     Distribution::Summary(summary, quantiles, sum) => {
                         let count = summary.count();
-                        if count == 0 {
-                            continue;
-                        }
                         wrote = true;
                         let snapshot = summary.snapshot(Instant::now());
                         for quantile in quantiles.iter() {
@@ -192,9 +183,6 @@ impl Inner {
                     }
                     Distribution::Histogram(histogram) => {
                         let count = histogram.count();
-                        if count == 0 {
-                            continue;
-                        }
                         wrote = true;
                         for (le, count) in histogram.buckets() {
                             write_metric_line(


### PR DESCRIPTION
0 is a valid value for a gauge or a counter (e.g. "number of active sessions"
can easily be zero and that state is distinct from is distinct 1) and zero
samples in a period is legit for a histogram over an interval.

For gauges we should also not reset to zero on each render, but we should
continue to do so for counters.

Suppression of idle metrics should be done using `StatsdBuilder::idle_timeout`.

Fixes #5 (at least in line with my opinion in https://github.com/dialtone/metrics-exporter-dogstatsd/issues/5#issuecomment-2478346560).